### PR TITLE
Mathjaxをhttpsで呼び出すようにする

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
     }
   });
 </script>
-<script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
     }
   });
 </script>
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 


### PR DESCRIPTION
GitHub Pagesはhttpsでもホストされているため、[dai1741.github.io/maximum-algo-2012](https://dai1741.github.io/maximum-algo-2012)はhttpsで見ることができますが、そうした場合、Mathjaxがhttpsで呼び出されていないため表示されないようです。
- httpsでの表示
    <img width="1440" alt="image" src="https://github.com/dai1741/maximum-algo-2012/assets/52094083/9e73b34f-7dfd-4a6a-9fb2-78ada2df50e9">
- httpでの表示
    <img width="1440" alt="image" src="https://github.com/dai1741/maximum-algo-2012/assets/52094083/a4eb703b-20c1-4ee7-9362-2c79daba3e78">
- httpsでのエラー
    ```
    Mixed Content: The page at 'https://dai1741.github.io/maximum-algo-2012/docs/dynamic-programming/' was loaded over HTTPS, but requested an insecure script 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'. This request has been blocked; the content must be served over HTTPS.
    ```

また、[公式のCDNはサポートを終了する](https://www.mathjax.org/cdn-shutting-down/)ようなので、それに対する対応も含めました。

